### PR TITLE
Update dependencies

### DIFF
--- a/paper_trail-sinatra.gemspec
+++ b/paper_trail-sinatra.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   # `::PaperTrail::Sinatra`.
   spec.add_dependency "paper_trail", [">= 7", "< 9"]
 
-  spec.add_dependency "sinatra", [">= 1.0.0", "<= 2"]
+  spec.add_dependency "sinatra", [">= 1.0.0", "< 3"]
   spec.add_development_dependency "rack-test", "~> 0.6"
   spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "sqlite3", "~> 1.3"

--- a/paper_trail-sinatra.gemspec
+++ b/paper_trail-sinatra.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   # This gem should # not be used with PT < 7 because both define
   # `::PaperTrail::Sinatra`.
-  spec.add_dependency "paper_trail", "~> 7"
+  spec.add_dependency "paper_trail", [">= 7", "< 9"]
 
   spec.add_dependency "sinatra", [">= 1.0.0", "<= 2"]
   spec.add_development_dependency "rack-test", "~> 0.6"


### PR DESCRIPTION
two changes:
- allow paper trail 8
- allow all versions of sinatra 2.x. the current constraint limits this to 2.0.0 - which is the only version currently released, but will be out of date as soon as 2.0.1 is out.