### PR TITLE
two helpers for rails consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ Breaking Changes
 
 Added
 
-- None
+- Two functions inherit from rails
+  - info_for_paper_trail
+  - paper_trail_enabled_for_request
 
 Fixed
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ user_for_paper_trail
 # Returns any information about the controller or request that you want
 # PaperTrail to store alongside any changes that occur.
 info_for_paper_trail
+
+# Turn PaperTrail off for per request
+paper_trail_enabled_for_request
 ```
 
 If you're using the modular [`Sinatra::Base`][4] style of application, you will

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ user_for_paper_trail
 # PaperTrail to store alongside any changes that occur.
 info_for_paper_trail
 
-# Turn PaperTrail off for per request
+# Returns `true` (default) or `false` to turn PaperTrail on/off for per request.
 paper_trail_enabled_for_request
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,12 +32,20 @@ into the `create_versions` migration that was generated into your `db/migrate` d
 
 5. Add `has_paper_trail` to the models you want to track.
 
-PaperTrail provides a helper extension that acts similar to the controller mixin
+PaperTrail provides some helper extensions that acts similar to the controller mixin
 it provides for `Rails` applications.
 
-It will set `PaperTrail.whodunnit` to whatever is returned by a method named
-`user_for_paper_trail` which you can define inside your Sinatra Application. (by
-default it attempts to invoke a method named `current_user`)
+In your helpers you can override these methods:
+
+```ruby
+# Returns the user who is responsible for any changes that occur.
+# Defaults to current_user.
+user_for_paper_trail
+
+# Returns any information about the controller or request that you want
+# PaperTrail to store alongside any changes that occur.
+info_for_paper_trail
+```
 
 If you're using the modular [`Sinatra::Base`][4] style of application, you will
 need to register the extension:

--- a/lib/paper_trail/sinatra.rb
+++ b/lib/paper_trail/sinatra.rb
@@ -10,7 +10,10 @@ module PaperTrail
     def self.registered(app)
       app.use RequestStore::Middleware
       app.helpers self
-      app.before { set_paper_trail_whodunnit }
+      app.before {
+        set_paper_trail_whodunnit
+        set_paper_trail_request_info
+      }
     end
 
     protected
@@ -27,12 +30,21 @@ module PaperTrail
       current_user
     end
 
+    def info_for_paper_trail
+      {}
+    end
+
     private
 
     # Tells PaperTrail who is responsible for any changes that occur.
     def set_paper_trail_whodunnit
       @set_paper_trail_whodunnit_called = true
       ::PaperTrail.whodunnit = user_for_paper_trail if ::PaperTrail.enabled?
+    end
+
+    def set_paper_trail_request_info
+      @set_paper_trail_request_info_called = true
+      ::PaperTrail.controller_info = info_for_paper_trail
     end
   end
 end

--- a/lib/paper_trail/sinatra.rb
+++ b/lib/paper_trail/sinatra.rb
@@ -31,10 +31,33 @@ module PaperTrail
       current_user
     end
 
+    # Returns any information about the controller or request that you
+    # want PaperTrail to store alongside any changes that occur.  By
+    # default this returns an empty hash.
+    #
+    # Override this method in your controller to return a hash of any
+    # information you need.  The hash's keys must correspond to columns
+    # in your `versions` table, so don't forget to add any new columns
+    # you need.
+    #
+    # For example:
+    #
+    #     {:ip => request.remote_ip, :user_agent => request.user_agent}
+    #
+    # The columns `ip` and `user_agent` must exist in your `versions` # table.
+    #
+    # Use the `:meta` option to
+    # `PaperTrail::Model::ClassMethods.has_paper_trail` to store any extra
+    # model-level data you need.
     def info_for_paper_trail
       {}
     end
 
+    # Returns `true` (default) or `false` depending on whether PaperTrail
+    # should be active for the current request.
+    #
+    # Override this method in your controller to specify when PaperTrail
+    # should be off.
     def paper_trail_enabled_for_request
       ::PaperTrail.enabled?
     end
@@ -43,17 +66,18 @@ module PaperTrail
 
     # Tells PaperTrail who is responsible for any changes that occur.
     def set_paper_trail_whodunnit
-      @set_paper_trail_whodunnit_called = true
       ::PaperTrail.whodunnit = user_for_paper_trail if ::PaperTrail.enabled?
     end
 
+    # Tells PaperTrail any information from the controller you want to store
+    # alongside any changes that occur.
     def set_paper_trail_request_info
-      @set_paper_trail_request_info_called = true
       ::PaperTrail.controller_info = info_for_paper_trail if ::PaperTrail.enabled?
     end
 
+    # Tells PaperTrail whether versions should be saved in the current
+    # request.
     def set_paper_trail_enabled_for_request
-      @set_paper_trail_enabled_for_request_called = true
       ::PaperTrail.enabled_for_controller = paper_trail_enabled_for_request if ::PaperTrail.enabled?
     end
   end

--- a/lib/paper_trail/sinatra.rb
+++ b/lib/paper_trail/sinatra.rb
@@ -49,12 +49,12 @@ module PaperTrail
 
     def set_paper_trail_request_info
       @set_paper_trail_request_info_called = true
-      ::PaperTrail.controller_info = info_for_paper_trail
+      ::PaperTrail.controller_info = info_for_paper_trail if ::PaperTrail.enabled?
     end
 
     def set_paper_trail_enabled_for_request
       @set_paper_trail_enabled_for_request_called = true
-      ::PaperTrail.enabled_for_controller = paper_trail_enabled_for_request
+      ::PaperTrail.enabled_for_controller = paper_trail_enabled_for_request if ::PaperTrail.enabled?
     end
   end
 end

--- a/lib/paper_trail/sinatra.rb
+++ b/lib/paper_trail/sinatra.rb
@@ -13,6 +13,7 @@ module PaperTrail
       app.before {
         set_paper_trail_whodunnit
         set_paper_trail_request_info
+        set_paper_trail_enabled_for_request
       }
     end
 
@@ -34,6 +35,10 @@ module PaperTrail
       {}
     end
 
+    def paper_trail_enabled_for_request
+      ::PaperTrail.enabled?
+    end
+
     private
 
     # Tells PaperTrail who is responsible for any changes that occur.
@@ -45,6 +50,11 @@ module PaperTrail
     def set_paper_trail_request_info
       @set_paper_trail_request_info_called = true
       ::PaperTrail.controller_info = info_for_paper_trail
+    end
+
+    def set_paper_trail_enabled_for_request
+      @set_paper_trail_enabled_for_request_called = true
+      ::PaperTrail.enabled_for_controller = paper_trail_enabled_for_request
     end
   end
 end

--- a/spec/create_db.sql
+++ b/spec/create_db.sql
@@ -9,8 +9,8 @@ We don't need to test against other RDBMS, sqlite is fine. Still, migrations
 provide some convenient methods.
 */
 
-drop table versions;
-drop table widgets;
+drop table if exists versions;
+drop table if exists widgets;
 
 create table versions (
   id integer primary key,
@@ -21,7 +21,9 @@ create table versions (
   object varchar,
   object_changes varchar,
   transaction_id integer,
-  created_at datetime
+  created_at datetime,
+  ip varchar,
+  user_agent varchar
 );
 
 create table widgets (

--- a/spec/sinatra_spec.rb
+++ b/spec/sinatra_spec.rb
@@ -21,7 +21,7 @@ module Sinatra
     end
 
     def paper_trail_enabled_for_request
-      request.user_agent =~ /chrome/
+      request.user_agent.to_s =~ /^(?!webkit)/
     end
   end
 end
@@ -34,7 +34,17 @@ RSpec.describe "classic sinatra application" do
   end
 
   context "`PaperTrail::Sinatra` in a `Sinatra::Application` application" do
-    it "sets the `user_for_paper_trail` from the `current_user` method, also sets `info_for_paper_trail` and `paper_trail_enabled_for_request`" do
+    it "sets the `user_for_paper_trail` from the `current_user` method" do
+      get "/test"
+      expect(last_response.body).to eq("Hai")
+      widget = Widget.last
+      expect(widget).to_not be_nil
+      expect(widget.name).to eq("bar")
+      expect(widget.versions.size).to eq(1)
+      expect(widget.versions.first.whodunnit).to eq("raboof")
+    end
+
+    it "sets `info_for_paper_trail`" do
       env "HTTP_USER_AGENT", "chrome"
       env "HTTP_X_FORWARDED_FOR", "8.8.8.8"
       get "/test"
@@ -46,15 +56,16 @@ RSpec.describe "classic sinatra application" do
       expect(widget.versions.first.whodunnit).to eq("raboof")
       expect(widget.versions.first.ip).to eq("8.8.8.8")
       expect(widget.versions.first.user_agent).to eq("chrome")
+    end
 
-      # change user agent
+    it "sets `paper_trail_enabled_for_request`" do
       env "HTTP_USER_AGENT", "webkit"
       get "/test"
       expect(last_response.body).to eq("Hai")
-      widget2 = Widget.last
-      expect(widget2).to_not be_nil
-      expect(widget2.name).to eq("bar")
-      expect(widget2.versions.size).to eq(0)
+      widget = Widget.last
+      expect(widget).to_not be_nil
+      expect(widget.name).to eq("bar")
+      expect(widget.versions.size).to eq(0)
     end
   end
 end

--- a/spec/sinatra_spec.rb
+++ b/spec/sinatra_spec.rb
@@ -15,6 +15,10 @@ module Sinatra
     def current_user
       @current_user ||= OpenStruct.new(id: "raboof")
     end
+
+    def info_for_paper_trail
+      { ip: request.ip, user_agent: request.user_agent }
+    end
   end
 end
 
@@ -26,7 +30,9 @@ RSpec.describe "classic sinatra application" do
   end
 
   context "`PaperTrail::Sinatra` in a `Sinatra::Application` application" do
-    it "sets the `user_for_paper_trail` from the `current_user` method" do
+    it "sets the `user_for_paper_trail` from the `current_user` method, also sets `info_for_paper_trail`" do
+      env "HTTP_USER_AGENT", "chrome"
+      env "HTTP_X_FORWARDED_FOR", "8.8.8.8"
       get "/test"
       expect(last_response.body).to eq("Hai")
       widget = Widget.last
@@ -34,6 +40,8 @@ RSpec.describe "classic sinatra application" do
       expect(widget.name).to eq("bar")
       expect(widget.versions.size).to eq(1)
       expect(widget.versions.first.whodunnit).to eq("raboof")
+      expect(widget.versions.first.ip).to eq("8.8.8.8")
+      expect(widget.versions.first.user_agent).to eq("chrome")
     end
   end
 end


### PR DESCRIPTION
```controller_info``` and ```enabled_for_controller``` are available,
but sinatra has not controller, ```paper_trail_enabled_for_controller``` named to ```paper_trail_enabled_for_request```