### PR TITLE
Drop activesupport dependency

### DIFF
--- a/lib/paper_trail/sinatra.rb
+++ b/lib/paper_trail/sinatra.rb
@@ -20,15 +20,14 @@ module PaperTrail
     protected
 
     # Returns the user who is responsible for any changes that occur.
-    # By default this calls `current_user` and returns the result.
+    # By default this calls `current_user#id` and falls back to
+    # `current_user`.
     #
     # Override this method in your controller to call a different
     # method, e.g. `current_person`, or anything you like.
     def user_for_paper_trail
       return unless defined?(current_user)
-      ActiveSupport::VERSION::MAJOR >= 4 ? current_user.try!(:id) : current_user.try(:id)
-    rescue NoMethodError
-      current_user
+      current_user&.id || current_user
     end
 
     # Returns any information about the controller or request that you

--- a/paper_trail-sinatra.gemspec
+++ b/paper_trail-sinatra.gemspec
@@ -19,8 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_dependency "activesupport", [">= 4.2", "< 6"]
-
   # This gem should not be used with PT < 7 because both define
   # `::PaperTrail::Sinatra`.
   spec.add_dependency "paper_trail", [">= 9", "< 11"]


### PR DESCRIPTION
Switch to safe navigation operator

Allows for dropping the activesupport dependency. paper_trail 10+
supports activerecord < 6.1. The activesupport < 6 dependency of
paper_trail-sinatra artificially hinders the use of activerecord 6.0

As ruby < 2.3 support was dropped a while ago, the safe navigation
operator can be adopted safely.