### PR TITLE
Run tests on Sinatra 3 / Papertrail 13

### DIFF
--- a/gemfiles/pt13_sinatra2.rb
+++ b/gemfiles/pt13_sinatra2.rb
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+gemspec(path: "..")
+gem "activesupport", "~> 7.0"
+gem "paper_trail", "~> 13.0"
+gem "sinatra", "~> 2.0.0"

--- a/gemfiles/pt13_sinatra3.rb
+++ b/gemfiles/pt13_sinatra3.rb
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+gemspec(path: "..")
+gem "activesupport", "~> 7.0"
+gem "paper_trail", "~> 13.0"
+gem "sinatra", "~> 3.0.0"

--- a/paper_trail-sinatra.gemspec
+++ b/paper_trail-sinatra.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   # `::PaperTrail::Sinatra`.
   spec.add_dependency "paper_trail", ">= 9"
 
-  spec.add_dependency "sinatra", [">= 1.0.0", "< 3"]
+  spec.add_dependency "sinatra", [">= 1.0.0", "< 4"]
   spec.add_development_dependency "bundler", [">= 1.13", "< 3"]
   spec.add_development_dependency "rack-test", "~> 0.6"
   spec.add_development_dependency "rspec", "~> 3.7"


### PR DESCRIPTION
At the beginning of the week, Sinatra 3 was released. I don't see any changes, which would affect the papertrail integration. So I suggest to relax the version requirements and allow Sinatra 3 as well.

Adding gemfiles for PaperTrail 13 with Sinatra 2 and 3.